### PR TITLE
feat: add efs stack, cleanup typing

### DIFF
--- a/lib/seamless-stack.ts
+++ b/lib/seamless-stack.ts
@@ -1,32 +1,39 @@
-import * as cdk from 'aws-cdk-lib';
-import { Construct } from 'constructs';
-import { EcsStack } from './stacks/ecs-stack';
-import { SnsStack } from './stacks/sns-stack';
-import { StateMachineStack } from './stacks/state-machine-stack';
+import { Stack, StackProps } from 'aws-cdk-lib';
 import { VpcStack } from './stacks/vpc-stack';
+import { EfsStack } from './stacks/efs-stack';
+import { SnsStack } from './stacks/sns-stack';
+import { EcsStack } from './stacks/ecs-stack';
+import { StateMachineStack } from './stacks/state-machine-stack';
+import { RdsStack } from './stacks/rds-stack';
+import { Construct } from 'constructs';
 
 import { config } from 'dotenv';
-import { RdsStack } from './stacks/rds-stack';
 config();
 
-export class SeamlessStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+export class SeamlessStack extends Stack {
+  constructor(scope: Construct, id: string, props: StackProps) {
     super(scope, id, props);
 
     // VPC
     const vpcStack = new VpcStack(this, 'seamless-vpc');
+
+    // EFS
+    const efsStack = new EfsStack(this, 'seamless-efs', { vpc: vpcStack.vpc });
+    efsStack.addDependency(vpcStack);
 
     // SNS
     const snsStack = new SnsStack(this, 'seamless-sns', {
       snsSubscriberUrl: process.env.SNS_SUBSCRIBER_URL,
     });
 
+    // ECS
     const ecsStack = new EcsStack(this, 'seamless-ecs', {
       vpc: vpcStack.vpc,
     });
 
     ecsStack.addDependency(vpcStack);
 
+    // RDS
     // const rdsStack = new RdsStack(this, 'seamless-rds', {
     //   vpc: vpcStack.vpc,
     // });

--- a/lib/stacks/efs-stack.ts
+++ b/lib/stacks/efs-stack.ts
@@ -1,0 +1,42 @@
+import { Construct } from 'constructs';
+import { NestedStack, NestedStackProps, RemovalPolicy } from 'aws-cdk-lib';
+import { IVpc } from 'aws-cdk-lib/aws-ec2';
+import {
+  FileSystem,
+  LifecyclePolicy,
+  PerformanceMode,
+  ThroughputMode,
+  OutOfInfrequentAccessPolicy,
+} from 'aws-cdk-lib/aws-efs';
+
+interface EfsStackProps extends NestedStackProps {
+  vpc: IVpc;
+}
+
+export class EfsStack extends NestedStack {
+  public readonly efs: FileSystem;
+
+  constructor(scope: Construct, id: string, props: EfsStackProps) {
+    super(scope, id, props);
+
+    // Prop validation
+    if (!props.vpc) {
+      throw new Error('No VPC provided');
+    }
+
+    // Create file system to serve as shared Docker volume
+    this.efs = new FileSystem(this, 'seamless-efs', {
+      vpc: props.vpc,
+      fileSystemName: 'SeamlessEFS',
+      enableAutomaticBackups: true,
+      encrypted: true,
+      performanceMode: PerformanceMode.GENERAL_PURPOSE,
+      throughputMode: ThroughputMode.BURSTING,
+      lifecyclePolicy: LifecyclePolicy.AFTER_14_DAYS,
+      outOfInfrequentAccessPolicy: OutOfInfrequentAccessPolicy.AFTER_1_ACCESS,
+      removalPolicy: RemovalPolicy.DESTROY,
+    });
+
+    this.efs.connections.allowDefaultPortFromAnyIpv4('Allow NFS');
+  }
+}

--- a/lib/stacks/vpc-stack.ts
+++ b/lib/stacks/vpc-stack.ts
@@ -1,22 +1,21 @@
-import * as cdk from 'aws-cdk-lib';
-import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { NestedStack, NestedStackProps } from 'aws-cdk-lib';
+import { Vpc, IVpc, IpAddresses, SubnetType } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 
-export class VpcStack extends cdk.NestedStack {
-  vpc: ec2.Vpc;
+export class VpcStack extends NestedStack {
+  public readonly vpc: IVpc;
 
-  constructor(scope: Construct, id: string, props?: cdk.NestedStackProps) {
+  constructor(scope: Construct, id: string, props?: NestedStackProps) {
     super(scope, id, props);
 
-    // Prop validation
-    this.vpc = new ec2.Vpc(this, 'seamless-vpc', {
-      ipAddresses: ec2.IpAddresses.cidr('10.0.0.0/16'),
+    this.vpc = new Vpc(this, 'seamless-vpc', {
+      ipAddresses: IpAddresses.cidr('10.0.0.0/16'),
       maxAzs: 2,
       subnetConfiguration: [
         {
           cidrMask: 24,
           name: 'publicSubnet',
-          subnetType: ec2.SubnetType.PUBLIC,
+          subnetType: SubnetType.PUBLIC,
         },
       ],
     });


### PR DESCRIPTION
Verified that EFS stack could successfully deploy to AWS using `cdk deploy`.
Updated imports to required modules only.