### PR TITLE
chore: update aws id naming; modularized imports

### DIFF
--- a/lib/seamless-stack.ts
+++ b/lib/seamless-stack.ts
@@ -15,33 +15,33 @@ export class SeamlessStack extends Stack {
     super(scope, id, props);
 
     // VPC
-    const vpcStack = new VpcStack(this, 'seamless-vpc');
+    const vpcStack = new VpcStack(this, 'SeamlessVpc');
 
     // EFS
-    const efsStack = new EfsStack(this, 'seamless-efs', { vpc: vpcStack.vpc });
+    const efsStack = new EfsStack(this, 'SeamlessEfs', { vpc: vpcStack.vpc });
     efsStack.addDependency(vpcStack);
 
     // SNS
-    const snsStack = new SnsStack(this, 'seamless-sns', {
+    const snsStack = new SnsStack(this, 'SeamlessSns', {
       snsSubscriberUrl: process.env.SNS_SUBSCRIBER_URL,
     });
 
     // ECS
-    const ecsStack = new EcsStack(this, 'seamless-ecs', {
+    const ecsStack = new EcsStack(this, 'SeamlessEcs', {
       vpc: vpcStack.vpc,
     });
 
     ecsStack.addDependency(vpcStack);
 
     // RDS
-    // const rdsStack = new RdsStack(this, 'seamless-rds', {
+    // const rdsStack = new RdsStack(this, 'SeamlessRds', {
     //   vpc: vpcStack.vpc,
     // });
 
     // State machine
     const stateMachineStack = new StateMachineStack(
       this,
-      'seamless-state-machine',
+      'SeamlessStateMachine',
       {
         topic: snsStack.topic,
         ecsCluster: ecsStack.cluster,

--- a/lib/stacks/ecs-stack.ts
+++ b/lib/stacks/ecs-stack.ts
@@ -1,23 +1,37 @@
-import * as cdk from 'aws-cdk-lib';
+import { NestedStack, NestedStackProps } from 'aws-cdk-lib';
+import {
+  IVpc,
+  InstanceType,
+  InstanceClass,
+  InstanceSize,
+  UserData,
+} from 'aws-cdk-lib/aws-ec2';
+import {
+  Cluster,
+  EcsOptimizedImage,
+  AsgCapacityProvider,
+  Ec2TaskDefinition,
+  NetworkMode,
+  ContainerImage,
+  AwsLogDriver,
+} from 'aws-cdk-lib/aws-ecs';
+import { Role, ServicePrincipal } from 'aws-cdk-lib/aws-iam';
+import { AutoScalingGroup } from 'aws-cdk-lib/aws-autoscaling';
 import { Construct } from 'constructs';
-import * as ec2 from 'aws-cdk-lib/aws-ec2';
-import * as ecs from 'aws-cdk-lib/aws-ecs';
-import * as iam from 'aws-cdk-lib/aws-iam';
-import * as autoscaling from 'aws-cdk-lib/aws-autoscaling';
 
-export interface EcsStackProps extends cdk.NestedStackProps {
-  vpc: ec2.Vpc;
+export interface EcsStackProps extends NestedStackProps {
+  readonly vpc: IVpc;
 }
 
-export class EcsStack extends cdk.NestedStack {
-  cluster: ecs.Cluster;
-  sampleSuccessTaskDefinition: ecs.TaskDefinition;
-  sampleFailureTaskDefinition: ecs.TaskDefinition;
-  prepareTaskDefinition: ecs.TaskDefinition;
-  codeQualityTaskDefinition: ecs.TaskDefinition;
-  testTaskDefinition: ecs.TaskDefinition;
-  buildTaskDefinition: ecs.TaskDefinition;
-  deployTaskDefinition: ecs.TaskDefinition;
+export class EcsStack extends NestedStack {
+  readonly cluster: Cluster;
+  readonly sampleSuccessTaskDefinition: Ec2TaskDefinition;
+  readonly sampleFailureTaskDefinition: Ec2TaskDefinition;
+  readonly prepareTaskDefinition: Ec2TaskDefinition;
+  readonly codeQualityTaskDefinition: Ec2TaskDefinition;
+  readonly testTaskDefinition: Ec2TaskDefinition;
+  readonly buildTaskDefinition: Ec2TaskDefinition;
+  readonly deployTaskDefinition: Ec2TaskDefinition;
 
   constructor(scope: Construct, id: string, props?: EcsStackProps) {
     super(scope, id, props);
@@ -27,39 +41,32 @@ export class EcsStack extends cdk.NestedStack {
       throw new Error('No VPC provided');
     }
 
-    // Autoscaling group for ECS instances to scale up/down to fit workloads
-    const autoScalingGroup = new autoscaling.AutoScalingGroup(
-      this,
-      'Auto-Scaling-Group',
-      {
-        vpc: props.vpc,
-        // Use public IP addresses or VPC internal interface
-        associatePublicIpAddress: true,
-        machineImage: ecs.EcsOptimizedImage.amazonLinux2(),
-        instanceType: ec2.InstanceType.of(
-          ec2.InstanceClass.T2,
-          ec2.InstanceSize.SMALL
-        ),
-        userData: ec2.UserData.forLinux(),
-        // grant ec2 instances communication access to ECS cluster
-        role: new iam.Role(this, 'ec2AccessRole', {
-          assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com'),
-        }),
-        minCapacity: 1,
-        desiredCapacity: 1,
-        maxCapacity: 10,
-      }
-    );
+    // Autoscaling group for ECS instances
+    const autoScalingGroup = new AutoScalingGroup(this, 'AutoScalingGroup', {
+      vpc: props.vpc,
+      // Use public IP addresses or VPC internal interface
+      associatePublicIpAddress: true,
+      machineImage: EcsOptimizedImage.amazonLinux2(),
+      instanceType: InstanceType.of(InstanceClass.T2, InstanceSize.MICRO),
+      userData: UserData.forLinux(),
+      // Grant ec2 instances communication access to ECS cluster
+      role: new Role(this, 'Ec2AccessRole', {
+        assumedBy: new ServicePrincipal('ec2.amazonaws.com'),
+      }),
+      minCapacity: 1,
+      desiredCapacity: 1,
+      maxCapacity: 10,
+    });
 
     // ECS cluster for executing tasks
-    this.cluster = new ecs.Cluster(this, 'Executor Cluster', {
+    this.cluster = new Cluster(this, 'ExecutorCluster', {
       vpc: props?.vpc,
       clusterName: 'executor-cluster',
       containerInsights: true,
     });
 
     // Register auto-scaling group as capacity provider for cluster
-    const capacityProvider = new ecs.AsgCapacityProvider(
+    const capacityProvider = new AsgCapacityProvider(
       this,
       'AsgCapacityProvider',
       { autoScalingGroup }
@@ -68,104 +75,103 @@ export class EcsStack extends cdk.NestedStack {
     this.cluster.addAsgCapacityProvider(capacityProvider);
 
     // Sample task definitions for use in AWS step functions
-
-    this.sampleSuccessTaskDefinition = new ecs.Ec2TaskDefinition(
+    this.sampleSuccessTaskDefinition = new Ec2TaskDefinition(
       this,
       'SampleSuccess',
       {
         family: 'sample-success-task-definition',
-        networkMode: ecs.NetworkMode.AWS_VPC,
+        networkMode: NetworkMode.AWS_VPC,
       }
     );
 
-    this.sampleSuccessTaskDefinition.addContainer('sample-success', {
-      image: ecs.ContainerImage.fromAsset('./lib/assets/sample_success'),
+    this.sampleSuccessTaskDefinition.addContainer('SampleSuccess', {
+      image: ContainerImage.fromAsset('./lib/assets/sample_success'),
       cpu: 256,
       memoryLimitMiB: 512,
-      logging: new ecs.AwsLogDriver({ streamPrefix: 'sample-success' }),
+      logging: new AwsLogDriver({ streamPrefix: 'sample-success' }),
     });
 
-    this.sampleFailureTaskDefinition = new ecs.Ec2TaskDefinition(
+    this.sampleFailureTaskDefinition = new Ec2TaskDefinition(
       this,
       'SampleFailure',
       {
         family: 'sample-failure-task-definition',
-        networkMode: ecs.NetworkMode.AWS_VPC,
+        networkMode: NetworkMode.AWS_VPC,
       }
     );
 
-    this.sampleFailureTaskDefinition.addContainer('sample-failure', {
-      image: ecs.ContainerImage.fromAsset('./lib/assets/sample_failure'),
+    this.sampleFailureTaskDefinition.addContainer('SampleFailure', {
+      image: ContainerImage.fromAsset('./lib/assets/sample_failure'),
       cpu: 256,
       memoryLimitMiB: 512,
-      logging: new ecs.AwsLogDriver({ streamPrefix: 'sample-failure' }),
+      logging: new AwsLogDriver({ streamPrefix: 'sample-failure' }),
     });
 
     // Pipeline stage executor task definitions
 
     /*
-    this.prepareTaskDefinition = new ecs.Ec2TaskDefinition(this, 'Prepare', {
+    this.prepareTaskDefinition = new Ec2TaskDefinition(this, 'Prepare', {
       family: 'prepare-task-definition',
-      networkMode: ecs.NetworkMode.AWS_VPC,
+      networkMode: NetworkMode.AWS_VPC,
     });
 
     this.prepareTaskDefinition.addContainer('prepare', {
-      image: ecs.ContainerImage.fromAsset('./lib/assets/prepare'),
+      image: ContainerImage.fromAsset('./lib/assets/prepare'),
       cpu: 256,
       memoryLimitMiB: 512,
-      logging: new ecs.AwsLogDriver({ streamPrefix: 'prepare' }),
+      logging: new AwsLogDriver({ streamPrefix: 'prepare' }),
     });
 
-    this.codeQualityTaskDefinition = new ecs.Ec2TaskDefinition(
+    this.codeQualityTaskDefinition = new Ec2TaskDefinition(
       this,
       'Code Quality',
       {
         family: 'code-quality-task-definition',
-        networkMode: ecs.NetworkMode.AWS_VPC,
+        networkMode: NetworkMode.AWS_VPC,
       }
     );
 
     this.codeQualityTaskDefinition.addContainer('code-quality', {
-      image: ecs.ContainerImage.fromAsset('./lib/assets/code_quality'),
+      image: ContainerImage.fromAsset('./lib/assets/code_quality'),
       cpu: 256,
       memoryLimitMiB: 512,
-      logging: new ecs.AwsLogDriver({ streamPrefix: 'code-quality' }),
+      logging: new AwsLogDriver({ streamPrefix: 'code-quality' }),
     });
 
-    this.testTaskDefinition = new ecs.Ec2TaskDefinition(this, 'Test', {
+    this.testTaskDefinition = new Ec2TaskDefinition(this, 'Test', {
       family: 'test-task-definition',
-      networkMode: ecs.NetworkMode.AWS_VPC,
+      networkMode: NetworkMode.AWS_VPC,
     });
 
     this.testTaskDefinition.addContainer('test', {
-      image: ecs.ContainerImage.fromAsset('./lib/assets/test'),
+      image: ContainerImage.fromAsset('./lib/assets/test'),
       cpu: 256,
       memoryLimitMiB: 512,
-      logging: new ecs.AwsLogDriver({ streamPrefix: 'test' }),
+      logging: new AwsLogDriver({ streamPrefix: 'test' }),
     });
 
-    this.buildTaskDefinition = new ecs.Ec2TaskDefinition(this, 'Build', {
+    this.buildTaskDefinition = new Ec2TaskDefinition(this, 'Build', {
       family: 'build-task-definition',
-      networkMode: ecs.NetworkMode.AWS_VPC,
+      networkMode: NetworkMode.AWS_VPC,
     });
 
     this.buildTaskDefinition.addContainer('build', {
-      image: ecs.ContainerImage.fromAsset('./lib/assets/build'),
+      image: ContainerImage.fromAsset('./lib/assets/build'),
       cpu: 256,
       memoryLimitMiB: 512,
-      logging: new ecs.AwsLogDriver({ streamPrefix: 'build' }),
+      logging: new AwsLogDriver({ streamPrefix: 'build' }),
     });
 
-    this.deployTaskDefinition = new ecs.Ec2TaskDefinition(this, 'Deploy', {
+    this.deployTaskDefinition = new Ec2TaskDefinition(this, 'Deploy', {
       family: 'deploy-task-definition',
-      networkMode: ecs.NetworkMode.AWS_VPC,
+      networkMode: NetworkMode.AWS_VPC,
     });
 
     this.deployTaskDefinition.addContainer('deploy', {
-      image: ecs.ContainerImage.fromAsset('./lib/assets/deploy'),
+      image: ContainerImage.fromAsset('./lib/assets/deploy'),
       cpu: 256,
       memoryLimitMiB: 512,
-      logging: new ecs.AwsLogDriver({ streamPrefix: 'deploy' }),
+      logging: new AwsLogDriver({ streamPrefix: 'deploy' }),
     });
     */
   }

--- a/lib/stacks/efs-stack.ts
+++ b/lib/stacks/efs-stack.ts
@@ -10,11 +10,11 @@ import {
 } from 'aws-cdk-lib/aws-efs';
 
 interface EfsStackProps extends NestedStackProps {
-  vpc: IVpc;
+  readonly vpc: IVpc;
 }
 
 export class EfsStack extends NestedStack {
-  public readonly efs: FileSystem;
+  readonly efs: FileSystem;
 
   constructor(scope: Construct, id: string, props: EfsStackProps) {
     super(scope, id, props);
@@ -25,9 +25,9 @@ export class EfsStack extends NestedStack {
     }
 
     // Create file system to serve as shared Docker volume
-    this.efs = new FileSystem(this, 'seamless-efs', {
+    this.efs = new FileSystem(this, 'SeamlessEfs', {
       vpc: props.vpc,
-      fileSystemName: 'SeamlessEFS',
+      fileSystemName: 'SeamlessEfs',
       enableAutomaticBackups: true,
       encrypted: true,
       performanceMode: PerformanceMode.GENERAL_PURPOSE,

--- a/lib/stacks/sns-stack.ts
+++ b/lib/stacks/sns-stack.ts
@@ -1,15 +1,15 @@
-import * as cdk from 'aws-cdk-lib';
-import * as sns from 'aws-cdk-lib/aws-sns';
+import { NestedStack, NestedStackProps } from 'aws-cdk-lib';
+import { Topic } from 'aws-cdk-lib/aws-sns';
 import { Construct } from 'constructs';
-import * as subs from 'aws-cdk-lib/aws-sns-subscriptions';
+import { UrlSubscription } from 'aws-cdk-lib/aws-sns-subscriptions';
 import { SNS_TOPIC_NAME } from '../constants';
 
-export interface SnsStackProps extends cdk.NestedStackProps {
-  snsSubscriberUrl: string | undefined;
+export interface SnsStackProps extends NestedStackProps {
+  readonly snsSubscriberUrl: string | undefined;
 }
 
-export class SnsStack extends cdk.NestedStack {
-  topic: sns.Topic;
+export class SnsStack extends NestedStack {
+  readonly topic: Topic;
 
   constructor(scope: Construct, id: string, props?: SnsStackProps) {
     super(scope, id, props);
@@ -20,12 +20,10 @@ export class SnsStack extends cdk.NestedStack {
     }
 
     // Create an SNS topic
-    const topic = new sns.Topic(this, SNS_TOPIC_NAME);
+    this.topic = new Topic(this, SNS_TOPIC_NAME);
 
     // Subscribe an HTTP endpoint to this topic
-    const urlSubscription = new subs.UrlSubscription(props.snsSubscriberUrl);
-    topic.addSubscription(urlSubscription);
-
-    this.topic = topic;
+    const urlSubscription = new UrlSubscription(props.snsSubscriberUrl);
+    this.topic.addSubscription(urlSubscription);
   }
 }

--- a/lib/stacks/vpc-stack.ts
+++ b/lib/stacks/vpc-stack.ts
@@ -3,12 +3,12 @@ import { Vpc, IVpc, IpAddresses, SubnetType } from 'aws-cdk-lib/aws-ec2';
 import { Construct } from 'constructs';
 
 export class VpcStack extends NestedStack {
-  public readonly vpc: IVpc;
+  readonly vpc: IVpc;
 
   constructor(scope: Construct, id: string, props?: NestedStackProps) {
     super(scope, id, props);
 
-    this.vpc = new Vpc(this, 'seamless-vpc', {
+    this.vpc = new Vpc(this, 'SeamlessVpc', {
       ipAddresses: IpAddresses.cidr('10.0.0.0/16'),
       maxAzs: 2,
       subnetConfiguration: [


### PR DESCRIPTION
Changed kebab-case AWS id names to PascalCase.
Modularized import from `import *` to `import { Module }`.