### PR TITLE
feat: add log prefixes with stage id

### DIFF
--- a/lib/assets/build/Dockerfile
+++ b/lib/assets/build/Dockerfile
@@ -1,4 +1,13 @@
 FROM --platform=linux/amd64 bentolor/docker-dind-awscli
+
 USER root
+
+# Install dumb-init
+RUN apk add dumb-init
+
 COPY commands.sh /
-ENTRYPOINT ["/bin/sh", "/commands.sh"]
+RUN chmod +x /commands.sh
+
+# Prefix logs with pipeline stage id
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["/bin/sh", "-c", "prefix=\"[${STAGE_ID}] \"; exec /commands.sh 2>&1 | sed -e \"s/^/${prefix}/\""]

--- a/lib/assets/code_quality/Dockerfile
+++ b/lib/assets/code_quality/Dockerfile
@@ -1,4 +1,12 @@
 FROM --platform=linux/amd64 node:18
 USER root
+
+# Install dumb-init
+RUN apt-get update && apt-get install -y dumb-init
+
 COPY commands.sh /
-ENTRYPOINT ["/bin/sh", "/commands.sh"]
+RUN chmod +x /commands.sh
+
+# Prefix logs with pipeline stage id
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["/bin/sh", "-c", "prefix=\"[${STAGE_ID}] \"; exec /commands.sh 2>&1 | sed -e \"s/^/${prefix}/\""]

--- a/lib/assets/prepare/Dockerfile
+++ b/lib/assets/prepare/Dockerfile
@@ -1,4 +1,12 @@
 FROM --platform=linux/amd64 node:18
 USER root
+
+# Install dumb-init
+RUN apt-get update && apt-get install -y dumb-init
+
 COPY commands.sh /
-ENTRYPOINT ["/bin/sh", "/commands.sh"]
+RUN chmod +x /commands.sh
+
+# Prefix logs with pipeline stage id
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["/bin/sh", "-c", "prefix=\"[${STAGE_ID}] \"; exec /commands.sh 2>&1 | sed -e \"s/^/${prefix}/\""]

--- a/lib/assets/unit_test/Dockerfile
+++ b/lib/assets/unit_test/Dockerfile
@@ -1,4 +1,12 @@
 FROM --platform=linux/amd64 node:18
 USER root
+
+# Install dumb-init
+RUN apt-get update && apt-get install -y dumb-init
+
 COPY commands.sh /
-ENTRYPOINT ["/bin/sh", "/commands.sh"]
+RUN chmod +x /commands.sh
+
+# Prefix logs with pipeline stage id
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["/bin/sh", "-c", "prefix=\"[${STAGE_ID}] \"; exec /commands.sh 2>&1 | sed -e \"s/^/${prefix}/\""]

--- a/lib/stacks/ecs-task-definitions.ts
+++ b/lib/stacks/ecs-task-definitions.ts
@@ -10,11 +10,11 @@ import {
   FireLensLogDriver,
   FirelensLogRouter,
   FirelensLogRouterType,
+  FirelensConfigFileType,
 } from 'aws-cdk-lib/aws-ecs';
 import {
   PolicyStatement,
   PolicyDocument,
-  Policy,
   Role,
   ServicePrincipal,
   Effect,
@@ -55,16 +55,16 @@ const createLoggingContainer = (
   taskDefinition: Ec2TaskDefinition
 ): FirelensLogRouter => {
   return new FirelensLogRouter(scope, containerName, {
-    memoryLimitMiB: 256,
+    image: ContainerImage.fromRegistry(
+      'public.ecr.aws/aws-observability/aws-for-fluent-bit:latest'
+    ),
     firelensConfig: {
       type: FirelensLogRouterType.FLUENTBIT,
       options: {
         enableECSLogMetadata: true,
       },
     },
-    image: ContainerImage.fromRegistry(
-      'public.ecr.aws/aws-observability/aws-for-fluent-bit:latest'
-    ),
+    memoryLimitMiB: 256,
     taskDefinition,
   });
 };

--- a/lib/stacks/state-machine-stack.ts
+++ b/lib/stacks/state-machine-stack.ts
@@ -55,6 +55,17 @@ enum StageStatus {
   FAILURE = 'STAGE_FAILURE',
 }
 
+const stageEnumToId = {
+  [Stage.START]: 'start',
+  [Stage.PREPARE]: 'prepare',
+  [Stage.CODE_QUALITY]: 'codeQuality',
+  [Stage.UNIT_TEST]: 'unitTest',
+  [Stage.BUILD]: 'build',
+  [Stage.INTEGRATION_TEST]: 'integrationTest',
+  [Stage.DEPLOY_STAGING]: 'deployStaging',
+  [Stage.DEPLOY_PROD]: 'deployProduction',
+};
+
 // NOTE: State machine expects a particular JSON payload. See `/state_machine_input.example.json` for more information
 export class StateMachineStack extends NestedStack {
   constructor(scope: Construct, id: string, props?: StateMachineStackProps) {
@@ -120,6 +131,10 @@ export class StateMachineStack extends NestedStack {
             containerDefinition:
               taskDefinition.defaultContainer as ContainerDefinition,
             environment: [
+              {
+                name: 'STAGE_ID',
+                value: JsonPath.stringAt(`$.stageIds.${stageEnumToId[stage]}`),
+              },
               {
                 name: 'AWS_REGION',
                 value: JsonPath.stringAt('$.containerVariables.awsRegion'),


### PR DESCRIPTION
Installed the [dumb-init](https://github.com/Yelp/dumb-init) process supervisor in all Dockerfiles. This wraps the container process so we can **prefix all `stdout` with the stage id**.

Example logs:
```
{"date":1677999321.130672,"source":"stdout","log":"[182801d8-ba2d-11ed-afa1-0242ac120001] Cloning into '/data/app'...", ...}
```

```
{"date":1677999361.563844,"source":"stdout","log":"[182801d8-ba2d-11ed-afa1-0242ac120004] Building Docker image", ...}
```

The downside is that for some reason, more logs are bundled together, and HTTP requests are not sent as frequently as before. It's less real-time.